### PR TITLE
Make addTCAcolumns compatible with TYPO3 CMS 6.2

### DIFF
--- a/ext_tables.php
+++ b/ext_tables.php
@@ -77,11 +77,7 @@ $tempColumns = array (
 );
 
 
-if (version_compare(TYPO3_branch, '6.1', '<')) {
-	t3lib_div::loadTCA('be_users');
-}
-
-t3lib_extMgm::addTCAcolumns('be_users',$tempColumns,1);
+t3lib_extMgm::addTCAcolumns('be_users',$tempColumns);
 t3lib_extMgm::addToAllTCAtypes('be_users','tx_piwikintegration_api_code;;;;1-1-1');
 
 //add flexform to pi1


### PR DESCRIPTION
Fix deprecation-log-entry: Usage of feInterface is no longer part of the TYPO3 CMS Core. Please check EXT:piwikintegration.
Also remove old, unused code; piwikintegration is marked as compatible with 6.2 and newer only.